### PR TITLE
Remove pluginClass entry for linux platform

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,4 +25,3 @@ flutter:
     platforms:
       linux:
         dartPluginClass: FlutterMidiCommandLinux
-        pluginClass: none


### PR DESCRIPTION
This plugin class metadata is deprecated and slated for removal: https://github.com/flutter/flutter/issues/57497